### PR TITLE
device.rs: increment metric instead of logging error

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -224,6 +224,10 @@ impl Block {
             used_any = true;
         }
 
+        if !used_any {
+            METRICS.block.no_avail_buffer.inc();
+        }
+
         used_any
     }
 

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -326,6 +326,8 @@ pub struct BlockDeviceMetrics {
     pub activate_fails: SharedMetric,
     /// Number of times when interacting with the space config of a block device failed.
     pub cfg_fails: SharedMetric,
+    /// No available buffer for the block queue.
+    pub no_avail_buffer: SharedMetric,
     /// Number of times when handling events on a block device failed.
     pub event_fails: SharedMetric,
     /// Number of failures in executing a request on a block device.
@@ -416,6 +418,10 @@ pub struct NetDeviceMetrics {
     pub activate_fails: SharedMetric,
     /// Number of times when interacting with the space config of a network device failed.
     pub cfg_fails: SharedMetric,
+    /// No available buffer for the net device rx queue.
+    pub no_rx_avail_buffer: SharedMetric,
+    /// No available buffer for the net device tx queue.
+    pub no_tx_avail_buffer: SharedMetric,
     /// Number of times when handling events on a network device failed.
     pub event_fails: SharedMetric,
     /// Number of events associated with the receiving queue.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 82.40
+COVERAGE_TARGET_PCT = 82.46
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
    We've introduced error log for the case when there is
    no available buffer for net RX queue. This can happen for
    heavy network traffic usage, and it is not an actual
    error, rather a limitation for which we must increment
    a specific metric.

    Added a similar metric for the block device case of
    no avail buffer.

    Signed-off-by: iulianbarbu <iul@amazon.com>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
